### PR TITLE
Add Notion integration registration page

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,4 +18,9 @@
     "js": ["content.js"]
   }],
   "action": { "default_popup": "popup.html" }
+  ,
+  "options_ui": {
+    "page": "register.html",
+    "open_in_tab": true
+  }
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,10 +11,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageId = url.pathname.replace(/\W/g, '');
     chrome.runtime.sendMessage({ cmd: 'toggle', pageId, level: 2 });
   });
+
+  document.getElementById('register').addEventListener('click', () => {
+    chrome.tabs.create({ url: chrome.runtime.getURL('register.html') });
+  });
 });
 </script>
 </head>
 <body>
 <button id="toggle">Convert headings</button>
+<button id="register">Setup Integration</button>
 </body>
 </html>

--- a/extension/register.html
+++ b/extension/register.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Notion Integration Setup</title>
+</head>
+<body>
+<h1>Notionインテグレーション登録</h1>
+<p>Notionでインテグレーションを作成し、生成された<strong>Internal Integration Token</strong>を入力してください。</p>
+<input id="token" type="text" placeholder="secret_xxx" style="width: 100%;" />
+<button id="save">登録</button>
+<span id="status"></span>
+<script src="register.js"></script>
+</body>
+</html>

--- a/extension/register.js
+++ b/extension/register.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const input = document.getElementById('token');
+  const status = document.getElementById('status');
+  const data = await chrome.storage.local.get('token');
+  if (data.token) input.value = data.token;
+  document.getElementById('save').addEventListener('click', async () => {
+    await chrome.storage.local.set({ token: input.value.trim() });
+    status.textContent = '登録しました';
+    setTimeout(() => { status.textContent = ''; }, 1500);
+  });
+});


### PR DESCRIPTION
## Summary
- add a registration page to store a Notion integration token
- open the registration page from the popup
- register the options page in manifest

## Testing
- `npm test` *(fails: could not find package.json)*