### PR TITLE
Add database ID configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ This repository provides a prototype extension that manipulates Notion pages.
 1. このページ右上の **Code** から **Download ZIP** を選び、ファイルを展開します。
 2. Chromeの拡張機能ページを開き、デベロッパーモードをオンにして「パッケージ化されていない拡張機能を読み込む」で展開したフォルダを指定します。
 3. Notionの `token_v2` を取得し、`token.txt` に貼り付けるか拡張機能の設定画面から保存します。
+4. 同じ設定画面で、リンク先を作成したいデータベースのIDも保存します。
 
 ## 主な機能 / Features
 - Notionページを素早く開いたり作成できます。
 - 見出しブロックを同レベルのトグル見出しに変換します。
 - 選択したテキストをタイトルとするページを作成し、選択部分をそのページへのリンクに置き換えます。
 
-拡張機能はNotion APIを利用し、`chrome.storage.local` に `token` として統合トークンを保存しておく必要があります。 
+拡張機能はNotion APIを利用し、`chrome.storage.local` に `token` として統合トークン、`database` としてデータベースIDを保存しておく必要があります。
 `extension/` ディレクトリにすべてのファイルが含まれています。
 
 ※ このプロジェクトは実験段階のため、予期しない動作をすることがあります。

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-document.addEventListener('mouseup', () => {
+document.addEventListener('mouseup', async () => {
   const sel = window.getSelection();
   const text = sel.toString().trim();
   if (!text) return;
@@ -7,10 +7,12 @@ document.addEventListener('mouseup', () => {
   const blockId = anchor.dataset.blockId;
   const start = sel.anchorOffset;
   const end = start + text.length;
+  const data = await chrome.storage.local.get('database');
+  if (!data.database) return;
   chrome.runtime.sendMessage({
     cmd: 'createPage',
     title: text,
-    db: '<DATABASE_ID>', // replace with your DB ID
+    db: data.database,
     blockId,
     start,
     end

--- a/extension/register.html
+++ b/extension/register.html
@@ -8,6 +8,8 @@
 <h1>Notionインテグレーション登録</h1>
 <p>Notionでインテグレーションを作成し、生成された<strong>Internal Integration Token</strong>を入力してください。</p>
 <input id="token" type="text" placeholder="secret_xxx" style="width: 100%;" />
+<p>作成したデータベースのIDも入力してください。</p>
+<input id="database" type="text" placeholder="xxxxxxxxxxxxxxxxxxxxxxxx" style="width: 100%;" />
 <button id="save">登録</button>
 <span id="status"></span>
 <script src="register.js"></script>

--- a/extension/register.js
+++ b/extension/register.js
@@ -1,10 +1,15 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  const input = document.getElementById('token');
+  const tokenInput = document.getElementById('token');
+  const dbInput = document.getElementById('database');
   const status = document.getElementById('status');
-  const data = await chrome.storage.local.get('token');
-  if (data.token) input.value = data.token;
+  const data = await chrome.storage.local.get(['token', 'database']);
+  if (data.token) tokenInput.value = data.token;
+  if (data.database) dbInput.value = data.database;
   document.getElementById('save').addEventListener('click', async () => {
-    await chrome.storage.local.set({ token: input.value.trim() });
+    await chrome.storage.local.set({
+      token: tokenInput.value.trim(),
+      database: dbInput.value.trim()
+    });
     status.textContent = '登録しました';
     setTimeout(() => { status.textContent = ''; }, 1500);
   });


### PR DESCRIPTION
## Summary
- include field for target database ID in registration page
- store the ID in chrome.storage.local
- use stored ID in content script instead of placeholder
- describe the new setup step in the README

## Testing
- `git status --short`