### PR TITLE
Add shortcut for linkifying selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository provides a prototype extension that manipulates Notion pages.
 - Notionページを素早く開いたり作成できます。
 - 見出しブロックを同レベルのトグル見出しに変換します。
 - 選択したテキストをタイトルとするページを作成し、選択部分をそのページへのリンクに置き換えます。
+  選択後に **Alt+L** を押すとリンク化が実行されます。
 
 拡張機能はNotion APIを利用し、`chrome.storage.local` に `token` として統合トークン、`database` としてデータベースIDを保存しておく必要があります。
 `extension/` ディレクトリにすべてのファイルが含まれています。

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,7 @@
-document.addEventListener('mouseup', async () => {
+// Trigger page creation and link insertion when Alt+L is pressed
+// after selecting text in a Notion block
+document.addEventListener('keydown', async e => {
+  if (!(e.altKey && e.key.toLowerCase() === 'l')) return;
   const sel = window.getSelection();
   const text = sel.toString().trim();
   if (!text) return;


### PR DESCRIPTION
## Summary
- allow link creation via **Alt+L** after selecting text
- document the new shortcut in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fc9e1a490832688a7c753a7d980e6