### PR TITLE
Improve page ID parsing in popup

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -25,8 +25,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('toggle').addEventListener('click', async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    const url = new URL(tab.url);
-    const pageId = url.pathname.replace(/\W/g, '');
+    const match = tab.url.match(/[0-9a-f]{32}/);
+    if (!match) {
+      msg.textContent = 'Invalid page URL';
+      setTimeout(() => { msg.textContent = ''; }, 1500);
+      return;
+    }
+    const pageId = match[0];
     chrome.runtime.sendMessage({ cmd: 'toggle', pageId, level: 2 });
   });
 


### PR DESCRIPTION
## Summary
- update toggle logic in `extension/popup.js` to detect page IDs using a regex
- display an error message if no page ID is found

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fddbdb96c83269d169acc8e6c5c05