### PR TITLE
Improve setup instructions and popup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This repository provides a prototype extension that manipulates Notion pages.
 ## 使い方 / Usage
 1. このページ右上の **Code** から **Download ZIP** を選び、ファイルを展開します。
 2. Chromeの拡張機能ページを開き、デベロッパーモードをオンにして「パッケージ化されていない拡張機能を読み込む」で展開したフォルダを指定します。
-3. Notionで作成したインテグレーションのトークンを `token.txt` に保存するか拡張機能の設定画面から登録します。
-4. 同じ設定画面で、リンク先を作成したいデータベースのIDも保存します。
+3. 拡張機能の設定画面から、Notionで作成したインテグレーションのトークンとページを作成したいデータベースのIDを登録します。データベースはインテグレーションと共有しておく必要があります。
 
 ## 主な機能 / Features
 - Notionページを素早く開いたり作成できます。
@@ -15,7 +14,7 @@ This repository provides a prototype extension that manipulates Notion pages.
 - 選択したテキストをタイトルとするページを作成し、選択部分をそのページへのリンクに置き換えます。
   選択後に **Alt+L** を押すとリンク化が実行されます。
 
-拡張機能はNotion APIを利用し、`chrome.storage.local` に `token` として統合トークン、`database` としてデータベースIDを保存しておく必要があります。
+拡張機能はNotion APIを利用し、`chrome.storage.local` に `token` として統合トークン、`database` としてデータベースIDを保存しておく必要があります。これらは設定画面から入力できます。
 `extension/` ディレクトリにすべてのファイルが含まれています。
 
 ※ このプロジェクトは実験段階のため、予期しない動作をすることがあります。

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -20,6 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await chrome.runtime.sendMessage({ cmd: 'createNewPage', title });
     if (res && res.url) {
       chrome.tabs.create({ url: res.url });
+    } else {
+      msg.textContent = 'Failed to create page';
+      setTimeout(() => { msg.textContent = ''; }, 1500);
     }
   });
 


### PR DESCRIPTION
## Summary
- document how to configure the token and database from the options page and remind users to share the database with the integration
- notify the user when page creation fails in popup.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fddbebcac8326b2b0af479904e10b