### PR TITLE
fix pageId extraction for Notion toggle

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -25,8 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('toggle').addEventListener('click', async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    const url = new URL(tab.url);
-    const pageId = url.pathname.replace(/\W/g, '');
+    const match = tab.url.replace(/-/g, '').match(/[0-9a-f]{32}/i);
+    if (!match) return;
+    const pageId = match[0];
     chrome.runtime.sendMessage({ cmd: 'toggle', pageId, level: 2 });
   });
 


### PR DESCRIPTION
## Summary
- update popup.js to detect the Notion page ID by stripping hyphens from the tab URL and matching `[0-9a-f]{32}`

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684fded1d78c832682aa738f864ad69c