### PR TITLE
Add Jest tests and page id utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ This repository provides a prototype extension that manipulates Notion pages.
 `extension/` ディレクトリにすべてのファイルが含まれています。
 
 ※ このプロジェクトは実験段階のため、予期しない動作をすることがあります。
+
+## テスト実行方法 / Running Tests
+1. 依存関係をインストールするため `npm install` を実行します。
+2. `npm test` でユニットテストを実行できます。

--- a/__tests__/pageUtils.test.js
+++ b/__tests__/pageUtils.test.js
@@ -1,0 +1,11 @@
+const { extractPageId } = require('../extension/pageUtils');
+
+test('extract page id from notion url', () => {
+  const url = 'https://www.notion.so/My-Title-9c3014d857aa452aa10d6bdfe58c3a12';
+  expect(extractPageId(url)).toBe('MyTitle9c3014d857aa452aa10d6bdfe58c3a12');
+});
+
+test('ignore query and fragments', () => {
+  const url = 'https://www.notion.so/Some-Page-1234567890abcdef12345678?foo=1#section';
+  expect(extractPageId(url)).toBe('SomePage1234567890abcdef12345678');
+});

--- a/extension/pageUtils.js
+++ b/extension/pageUtils.js
@@ -1,0 +1,10 @@
+function extractPageId(urlString) {
+  const url = new URL(urlString);
+  return url.pathname.replace(/\W/g, '');
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { extractPageId };
+} else {
+  window.extractPageId = extractPageId;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Notion Tools</title>
+<script src="pageUtils.js"></script>
 <script src="popup.js"></script>
 </head>
 <body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -25,8 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('toggle').addEventListener('click', async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    const url = new URL(tab.url);
-    const pageId = url.pathname.replace(/\W/g, '');
+    const pageId = extractPageId(tab.url);
     chrome.runtime.sendMessage({ cmd: 'toggle', pageId, level: 2 });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "obsidian-like-notion",
+  "version": "1.0.0",
+  "description": "Prototype Notion helper extension",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with Jest for testing
- modularize page ID extraction into `pageUtils.js`
- update popup to use the new utility and load it in HTML
- document how to run the tests
- add unit tests for page ID extraction

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fded0a4fc832689a5d1a5dcd2b4c3