### PR TITLE
Enable heading conversion by selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository provides a prototype extension that manipulates Notion pages.
 
 ## 主な機能 / Features
 - Notionページを素早く作成できます。
-- 見出しブロックを同レベルのトグル見出しに変換します。
+- 見出しブロックを同レベルのトグル見出しに変換します。"Convert headings" ボタンは現在の選択範囲に含まれる見出しのみを対象とします。
 - 選択したテキストをタイトルとするページを作成し、選択部分をそのページへのリンクに置き換えます。
   選択後に **Alt+L** を押すとリンク化が実行されます。
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -21,3 +21,21 @@ document.addEventListener('keydown', async e => {
     end
   });
 });
+
+// Provide selected block IDs when requested by the extension
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg && msg.cmd === 'getSelectedBlockIds') {
+    const sel = window.getSelection();
+    const ids = [];
+    if (sel && sel.rangeCount) {
+      const range = sel.getRangeAt(0);
+      let ancestor = range.commonAncestorContainer;
+      if (ancestor.nodeType !== 1) ancestor = ancestor.parentElement;
+      const elements = ancestor.querySelectorAll('[data-block-id]');
+      elements.forEach(el => {
+        if (range.intersectsNode(el)) ids.push(el.dataset.blockId);
+      });
+    }
+    sendResponse({ blockIds: Array.from(new Set(ids)) });
+  }
+});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -17,10 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('toggle').addEventListener('click', async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    const match = tab.url.replace(/-/g, '').match(/[0-9a-f]{32}/i);
-    if (!match) return;
-    const pageId = match[0];
-    chrome.runtime.sendMessage({ cmd: 'toggle', pageId, level: 2 });
+    if (!tab) return;
+    const res = await chrome.tabs.sendMessage(tab.id, { cmd: 'getSelectedBlockIds' });
+    if (res && Array.isArray(res.blockIds) && res.blockIds.length) {
+      chrome.runtime.sendMessage({ cmd: 'toggleSelection', blockIds: res.blockIds, level: 2 });
+    }
   });
 
   document.getElementById('register').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- expose selected block IDs from the page via content script
- convert only selected headings to toggles
- wire the popup to request selection and call the background script
- document selection-based heading conversion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fef8b62488326b0828abd10127bc3