### PR TITLE
Improve fetch error handling

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -15,6 +15,7 @@ const NOTION_VERSION = '2022-06-28';
       }
     } catch (e) {
       // ignore if file not found
+      console.error('Failed to load default token:', e);
     }
   }
 })();
@@ -34,41 +35,70 @@ async function convertToToggle(pageId, level = 2) {
     'Content-Type': 'application/json'
   };
   // Retrieve child blocks
-  const res = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`,
-    { headers });
-  const data = await res.json();
+  let data;
+  try {
+    const res = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`, { headers });
+    if (!res.ok) throw new Error(res.statusText);
+    data = await res.json();
+  } catch (e) {
+    console.error('Failed to retrieve child blocks:', e);
+    return;
+  }
   for (const block of data.results) {
     if (block.type.startsWith('heading')) {
       // Archive old heading
-      await fetch(`https://api.notion.com/v1/blocks/${block.id}`, {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify({ archived: true })
-      });
+      try {
+        await fetch(`https://api.notion.com/v1/blocks/${block.id}`, {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify({ archived: true })
+        });
+      } catch (e) {
+        console.error('Failed to archive heading:', e);
+        continue;
+      }
       // Create toggle heading with same text
-      const createRes = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children`, {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify({
-          children: [{
-            object: 'block',
-            type: `toggle_heading_${level}`,
-            [`toggle_heading_${level}`]: {
-              rich_text: block[block.type].rich_text
-            }
-          }]
-        })
-      });
-      const createData = await createRes.json();
+      let createData;
+      try {
+        const createRes = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children`, {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify({
+            children: [{
+              object: 'block',
+              type: `toggle_heading_${level}`,
+              [`toggle_heading_${level}`]: {
+                rich_text: block[block.type].rich_text
+              }
+            }]
+          })
+        });
+        if (!createRes.ok) throw new Error(createRes.statusText);
+        createData = await createRes.json();
+      } catch (e) {
+        console.error('Failed to create toggle heading:', e);
+        continue;
+      }
       if (block.has_children) {
-        const childRes = await fetch(`https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`, { headers });
-        const childData = await childRes.json();
+        let childData;
+        try {
+          const childRes = await fetch(`https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`, { headers });
+          if (!childRes.ok) throw new Error(childRes.statusText);
+          childData = await childRes.json();
+        } catch (e) {
+          console.error('Failed to fetch nested blocks:', e);
+          continue;
+        }
         for (const child of childData.results) {
-          await fetch(`https://api.notion.com/v1/blocks/${child.id}`, {
-            method: 'PATCH',
-            headers,
-            body: JSON.stringify({ parent: { block_id: createData.results[0].id } })
-          });
+          try {
+            await fetch(`https://api.notion.com/v1/blocks/${child.id}`, {
+              method: 'PATCH',
+              headers,
+              body: JSON.stringify({ parent: { block_id: createData.results[0].id } })
+            });
+          } catch (e) {
+            console.error('Failed to move block:', e);
+          }
           await new Promise(r => setTimeout(r, 400));
         }
       }
@@ -84,7 +114,10 @@ chrome.runtime.onMessage.addListener(async msg => {
     await createLinkedPage(msg);
   } else if (msg.cmd === 'createNewPage') {
     const url = await createPage(msg.title);
-    return { url };
+    if (url) {
+      return { url };
+    }
+    return { error: 'Failed to create page' };
   }
 });
 
@@ -97,19 +130,33 @@ async function createLinkedPage({ title, db, blockId, start, end }) {
     'Notion-Version': NOTION_VERSION,
     'Content-Type': 'application/json'
   };
-  const pageRes = await fetch('https://api.notion.com/v1/pages', {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      parent: { database_id: db },
-      properties: {
-        Name: { title: [{ text: { content: title } }] }
-      }
-    })
-  });
-  const page = await pageRes.json();
-  const blockRes = await fetch(`https://api.notion.com/v1/blocks/${blockId}`, { headers });
-  const block = await blockRes.json();
+  let page;
+  try {
+    const pageRes = await fetch('https://api.notion.com/v1/pages', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        parent: { database_id: db },
+        properties: {
+          Name: { title: [{ text: { content: title } }] }
+        }
+      })
+    });
+    if (!pageRes.ok) throw new Error(pageRes.statusText);
+    page = await pageRes.json();
+  } catch (e) {
+    console.error('Failed to create page:', e);
+    return;
+  }
+  let block;
+  try {
+    const blockRes = await fetch(`https://api.notion.com/v1/blocks/${blockId}`, { headers });
+    if (!blockRes.ok) throw new Error(blockRes.statusText);
+    block = await blockRes.json();
+  } catch (e) {
+    console.error('Failed to retrieve block:', e);
+    return;
+  }
   const plain = block[block.type].rich_text.map(r => r.plain_text).join('');
   const before = plain.slice(0, start);
   const after = plain.slice(end);
@@ -118,11 +165,15 @@ async function createLinkedPage({ title, db, blockId, start, end }) {
     { text: { content: title, link: { url: page.url } } },
     { text: { content: after } }
   ];
-  await fetch(`https://api.notion.com/v1/blocks/${blockId}`, {
-    method: 'PATCH',
-    headers,
-    body: JSON.stringify({ [block.type]: { rich_text: richText } })
-  });
+  try {
+    await fetch(`https://api.notion.com/v1/blocks/${blockId}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ [block.type]: { rich_text: richText } })
+    });
+  } catch (e) {
+    console.error('Failed to update block text:', e);
+  }
 }
 
 // Create a new page in the configured database and return its URL
@@ -136,17 +187,23 @@ async function createPage(title) {
     'Notion-Version': NOTION_VERSION,
     'Content-Type': 'application/json'
   };
-  const pageRes = await fetch('https://api.notion.com/v1/pages', {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      parent: { database_id: data.database },
-      properties: {
-        Name: { title: [{ text: { content: title } }] }
-      }
-    })
-  });
-  const page = await pageRes.json();
-  return page.url;
+  try {
+    const pageRes = await fetch('https://api.notion.com/v1/pages', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        parent: { database_id: data.database },
+        properties: {
+          Name: { title: [{ text: { content: title } }] }
+        }
+      })
+    });
+    if (!pageRes.ok) throw new Error(pageRes.statusText);
+    const page = await pageRes.json();
+    return page.url;
+  } catch (e) {
+    console.error('Failed to create page:', e);
+    return null;
+  }
 }
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (res && res.url) {
       chrome.tabs.create({ url: res.url });
     } else {
-      msg.textContent = 'Failed to create page';
+      msg.textContent = res && res.error ? res.error : 'Failed to create page';
       setTimeout(() => { msg.textContent = ''; }, 1500);
     }
   });


### PR DESCRIPTION
## Summary
- handle errors for Notion API requests
- show popup errors from background responses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fefdef8608326a05b2cf171b3f461