### PR TITLE
Add Jest test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/__tests__/background.test.js
+++ b/__tests__/background.test.js
@@ -1,0 +1,16 @@
+const { getToken } = require('../extension/background.js');
+
+describe('getToken', () => {
+  test('returns token from chrome storage', async () => {
+    global.chrome = {
+      storage: {
+        local: {
+          get: jest.fn().mockResolvedValue({ token: 'abc123' }),
+        },
+      },
+    };
+
+    const token = await getToken();
+    expect(token).toBe('abc123');
+  });
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,23 +1,25 @@
 const NOTION_VERSION = '2022-06-28';
 
 // Load token from token.txt on first run
-(async () => {
-  const data = await chrome.storage.local.get('token');
-  if (!data.token) {
-    try {
-      const url = chrome.runtime.getURL('token.txt');
-      const res = await fetch(url);
-      if (res.ok) {
-        const text = (await res.text()).trim();
-        if (text) {
-          await chrome.storage.local.set({ token: text });
+if (typeof chrome !== 'undefined' && chrome.storage && chrome.runtime) {
+  (async () => {
+    const data = await chrome.storage.local.get('token');
+    if (!data.token) {
+      try {
+        const url = chrome.runtime.getURL('token.txt');
+        const res = await fetch(url);
+        if (res.ok) {
+          const text = (await res.text()).trim();
+          if (text) {
+            await chrome.storage.local.set({ token: text });
+          }
         }
+      } catch (e) {
+        // ignore if file not found
       }
-    } catch (e) {
-      // ignore if file not found
     }
-  }
-})();
+  })();
+}
 
 async function getToken() {
   const data = await chrome.storage.local.get('token');
@@ -199,5 +201,16 @@ async function createPage(title) {
   });
   const page = await pageRes.json();
   return page.url;
+}
+
+// Export for testing in Node environment
+if (typeof module !== 'undefined') {
+  module.exports = {
+    getToken,
+    convertToToggle,
+    convertBlocksToToggle,
+    createLinkedPage,
+    createPage,
+  };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "obsidian-like-notion",
+  "version": "0.1.0",
+  "description": "Utilities for the Notion page tweaking extension",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize package.json with Jest
- ignore `node_modules`
- export functions from `background.js` when running in Node
- add test verifying stored token retrieval

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff32c73e48326839364d109213737