### PR TITLE
Implement error handling and retry logic

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -25,21 +25,53 @@ async function getToken() {
   return data.token || '';
 }
 
+function notifyError(message) {
+  chrome.runtime.sendMessage({ error: message });
+}
+
+async function fetchWithRetry(url, options = {}, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(url, options);
+    if (res.status !== 429) {
+      return res;
+    }
+    await new Promise(r => setTimeout(r, 3000));
+  }
+  return fetch(url, options);
+}
+
+async function safeFetch(url, options, errorMessage) {
+  try {
+    const res = await fetchWithRetry(url, options);
+    if (!res.ok) throw new Error(res.statusText);
+    return res;
+  } catch (e) {
+    console.error(errorMessage, e);
+    notifyError(errorMessage);
+    throw e;
+  }
+}
+
 async function buildBlockCopy(id, headers) {
-  const res = await fetch(`https://api.notion.com/v1/blocks/${id}`, { headers });
-  if (!res.ok) throw new Error(res.statusText);
+  const res = await safeFetch(
+    `https://api.notion.com/v1/blocks/${id}`,
+    { headers },
+    'Failed to fetch block'
+  );
   const block = await res.json();
   const copy = { object: 'block', type: block.type, [block.type]: block[block.type] };
   if (block.has_children) {
-    const childRes = await fetch(`https://api.notion.com/v1/blocks/${id}/children?page_size=100`, { headers });
-    if (childRes.ok) {
-      const childData = await childRes.json();
-      copy.children = [];
-      for (const child of childData.results) {
-        const nested = await buildBlockCopy(child.id, headers);
-        copy.children.push(nested);
-        await new Promise(r => setTimeout(r, 400));
-      }
+    const childRes = await safeFetch(
+      `https://api.notion.com/v1/blocks/${id}/children?page_size=100`,
+      { headers },
+      'Failed to fetch child blocks'
+    );
+    const childData = await childRes.json();
+    copy.children = [];
+    for (const child of childData.results) {
+      const nested = await buildBlockCopy(child.id, headers);
+      copy.children.push(nested);
+      await new Promise(r => setTimeout(r, 400));
     }
   }
   return copy;
@@ -57,73 +89,89 @@ async function convertToToggle(pageId, level = 2) {
   // Retrieve child blocks
   let data;
   try {
-    const res = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`, { headers });
-    if (!res.ok) throw new Error(res.statusText);
+    const res = await safeFetch(
+      `https://api.notion.com/v1/blocks/${pageId}/children?page_size=100`,
+      { headers },
+      'Failed to retrieve child blocks'
+    );
     data = await res.json();
-  } catch (e) {
-    console.error('Failed to retrieve child blocks:', e);
+  } catch {
     return;
   }
   for (const block of data.results) {
     if (block.type.startsWith('heading')) {
       // Archive old heading
       try {
-        await fetch(`https://api.notion.com/v1/blocks/${block.id}`, {
-          method: 'PATCH',
-          headers,
-          body: JSON.stringify({ archived: true })
-        });
-      } catch (e) {
-        console.error('Failed to archive heading:', e);
+        await safeFetch(
+          `https://api.notion.com/v1/blocks/${block.id}`,
+          {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify({ archived: true })
+          },
+          'Failed to archive heading'
+        );
+      } catch {
         continue;
       }
       // Create toggle heading with same text
       let createData;
       try {
-        const createRes = await fetch(`https://api.notion.com/v1/blocks/${pageId}/children`, {
-          method: 'PATCH',
-          headers,
-          body: JSON.stringify({
-            children: [{
-              object: 'block',
-              type: `toggle_heading_${level}`,
-              [`toggle_heading_${level}`]: {
-                rich_text: block[block.type].rich_text
-              }
-            }]
-          })
-        });
-        if (!createRes.ok) throw new Error(createRes.statusText);
+        const createRes = await safeFetch(
+          `https://api.notion.com/v1/blocks/${pageId}/children`,
+          {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify({
+              children: [{
+                object: 'block',
+                type: `toggle_heading_${level}`,
+                [`toggle_heading_${level}`]: {
+                  rich_text: block[block.type].rich_text
+                }
+              }]
+            })
+          },
+          'Failed to create toggle heading'
+        );
         createData = await createRes.json();
-      } catch (e) {
-        console.error('Failed to create toggle heading:', e);
+      } catch {
         continue;
       }
       if (block.has_children) {
         let childData;
         try {
-          const childRes = await fetch(`https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`, { headers });
-          if (!childRes.ok) throw new Error(childRes.statusText);
+          const childRes = await safeFetch(
+            `https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`,
+            { headers },
+            'Failed to fetch nested blocks'
+          );
           childData = await childRes.json();
-        } catch (e) {
-          console.error('Failed to fetch nested blocks:', e);
+        } catch {
           continue;
         }
         for (const child of childData.results) {
           try {
             const copy = await buildBlockCopy(child.id, headers);
-            await fetch(`https://api.notion.com/v1/blocks/${createData.results[0].id}/children`, {
-              method: 'PATCH',
-              headers,
-              body: JSON.stringify({ children: [copy] })
-            });
-            await fetch(`https://api.notion.com/v1/blocks/${child.id}`, {
-              method: 'PATCH',
-              headers,
-              body: JSON.stringify({ archived: true })
-            });
-          } catch (e) {
-            console.error('Failed to copy block:', e);
+            await safeFetch(
+              `https://api.notion.com/v1/blocks/${createData.results[0].id}/children`,
+              {
+                method: 'PATCH',
+                headers,
+                body: JSON.stringify({ children: [copy] })
+              },
+              'Failed to append block'
+            );
+            await safeFetch(
+              `https://api.notion.com/v1/blocks/${child.id}`,
+              {
+                method: 'PATCH',
+                headers,
+                body: JSON.stringify({ archived: true })
+              },
+              'Failed to archive child block'
+            );
+          } catch {
           }
           await new Promise(r => setTimeout(r, 400));
         }
@@ -143,48 +191,70 @@ async function convertBlocksToToggle(blockIds, level = 2) {
     'Content-Type': 'application/json'
   };
   for (const id of blockIds) {
-    const res = await fetch(`https://api.notion.com/v1/blocks/${id}`, { headers });
+    const res = await safeFetch(
+      `https://api.notion.com/v1/blocks/${id}`,
+      { headers },
+      'Failed to fetch block'
+    );
     const block = await res.json();
     if (!block.type || !block.type.startsWith('heading')) continue;
     const parentId = block.parent.block_id || block.parent.page_id;
-    await fetch(`https://api.notion.com/v1/blocks/${block.id}`, {
-      method: 'PATCH',
-      headers,
-      body: JSON.stringify({ archived: true })
-    });
-    const createRes = await fetch(`https://api.notion.com/v1/blocks/${parentId}/children`, {
-      method: 'PATCH',
-      headers,
-      body: JSON.stringify({
-        children: [{
-          object: 'block',
-          type: `toggle_heading_${level}`,
-          [`toggle_heading_${level}`]: {
-            rich_text: block[block.type].rich_text
-          }
-        }]
-      })
-    });
+    await safeFetch(
+      `https://api.notion.com/v1/blocks/${block.id}`,
+      {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ archived: true })
+      },
+      'Failed to archive heading'
+    );
+    const createRes = await safeFetch(
+      `https://api.notion.com/v1/blocks/${parentId}/children`,
+      {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({
+          children: [{
+            object: 'block',
+            type: `toggle_heading_${level}`,
+            [`toggle_heading_${level}`]: {
+              rich_text: block[block.type].rich_text
+            }
+          }]
+        })
+      },
+      'Failed to create toggle heading'
+    );
     const createData = await createRes.json();
     if (block.has_children) {
-      const childRes = await fetch(`https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`, { headers });
+      const childRes = await safeFetch(
+        `https://api.notion.com/v1/blocks/${block.id}/children?page_size=100`,
+        { headers },
+        'Failed to fetch nested blocks'
+      );
       const childData = await childRes.json();
       for (const child of childData.results) {
         try {
           const copy = await buildBlockCopy(child.id, headers);
-          await fetch(`https://api.notion.com/v1/blocks/${createData.results[0].id}/children`, {
-            method: 'PATCH',
-            headers,
-            body: JSON.stringify({ children: [copy] })
-          });
-          await fetch(`https://api.notion.com/v1/blocks/${child.id}`, {
-            method: 'PATCH',
-            headers,
-            body: JSON.stringify({ archived: true })
-          });
-        } catch (e) {
-          console.error('Failed to copy block:', e);
-        }
+          await safeFetch(
+            `https://api.notion.com/v1/blocks/${createData.results[0].id}/children`,
+            {
+              method: 'PATCH',
+              headers,
+              body: JSON.stringify({ children: [copy] })
+            },
+            'Failed to append block'
+          );
+          await safeFetch(
+            `https://api.notion.com/v1/blocks/${child.id}`,
+            {
+              method: 'PATCH',
+              headers,
+              body: JSON.stringify({ archived: true })
+            },
+            'Failed to archive child block'
+          );
+        } catch {}
         await new Promise(r => setTimeout(r, 400));
       }
     }
@@ -219,29 +289,33 @@ async function createLinkedPage({ title, db, blockId, start, end }) {
   };
   let page;
   try {
-    const pageRes = await fetch('https://api.notion.com/v1/pages', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        parent: { database_id: db },
-        properties: {
-          Name: { title: [{ text: { content: title } }] }
-        }
-      })
-    });
-    if (!pageRes.ok) throw new Error(pageRes.statusText);
+    const pageRes = await safeFetch(
+      'https://api.notion.com/v1/pages',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          parent: { database_id: db },
+          properties: {
+            Name: { title: [{ text: { content: title } }] }
+          }
+        })
+      },
+      'Failed to create page'
+    );
     page = await pageRes.json();
-  } catch (e) {
-    console.error('Failed to create page:', e);
+  } catch {
     return;
   }
   let block;
   try {
-    const blockRes = await fetch(`https://api.notion.com/v1/blocks/${blockId}`, { headers });
-    if (!blockRes.ok) throw new Error(blockRes.statusText);
+    const blockRes = await safeFetch(
+      `https://api.notion.com/v1/blocks/${blockId}`,
+      { headers },
+      'Failed to retrieve block'
+    );
     block = await blockRes.json();
-  } catch (e) {
-    console.error('Failed to retrieve block:', e);
+  } catch {
     return;
   }
   const plain = block[block.type].rich_text.map(r => r.plain_text).join('');
@@ -253,14 +327,16 @@ async function createLinkedPage({ title, db, blockId, start, end }) {
     { text: { content: after } }
   ];
   try {
-    await fetch(`https://api.notion.com/v1/blocks/${blockId}`, {
-      method: 'PATCH',
-      headers,
-      body: JSON.stringify({ [block.type]: { rich_text: richText } })
-    });
-  } catch (e) {
-    console.error('Failed to update block text:', e);
-  }
+    await safeFetch(
+      `https://api.notion.com/v1/blocks/${blockId}`,
+      {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ [block.type]: { rich_text: richText } })
+      },
+      'Failed to update block text'
+    );
+  } catch {}
 }
 
 // Create a new page in the configured database and return its URL
@@ -275,21 +351,23 @@ async function createPage(title) {
     'Content-Type': 'application/json'
   };
   try {
-    const pageRes = await fetch('https://api.notion.com/v1/pages', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        parent: { database_id: data.database },
-        properties: {
-          Name: { title: [{ text: { content: title } }] }
-        }
-      })
-    });
-    if (!pageRes.ok) throw new Error(pageRes.statusText);
+    const pageRes = await safeFetch(
+      'https://api.notion.com/v1/pages',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          parent: { database_id: data.database },
+          properties: {
+            Name: { title: [{ text: { content: title } }] }
+          }
+        })
+      },
+      'Failed to create page'
+    );
     const page = await pageRes.json();
     return page.url;
-  } catch (e) {
-    console.error('Failed to create page:', e);
+  } catch {
     return null;
   }
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -2,6 +2,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const titleInput = document.getElementById('pageTitle');
   const msg = document.getElementById('status');
 
+  chrome.runtime.onMessage.addListener(res => {
+    if (res && res.error) {
+      msg.textContent = res.error;
+      setTimeout(() => { msg.textContent = ''; }, 1500);
+    }
+  });
+
 
   document.getElementById('createNewPage').addEventListener('click', async () => {
     const title = titleInput.value.trim();


### PR DESCRIPTION
## Summary
- notify popup when fetch errors occur
- add retry logic for 429 responses
- display runtime errors in popup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853b9cec8148326b4662748edb1d71a